### PR TITLE
Add economic calendar fetch

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,7 @@
 
 import streamlit as st
+import requests
+import pandas as pd
 
 st.title("Macro Trading Dashboard V2")
 st.write("Bienvenue dans votre outil d'analyse macroéconomique et géopolitique.")
@@ -10,3 +12,23 @@ st.write("Connexion aux API en cours...")
 
 # Exemple de placeholder
 st.success("✅ Les API clés sont bien connectées.")
+
+
+def fetch_economic_calendar(api_key: str) -> pd.DataFrame:
+    """Fetch economic calendar data from TradingEconomics."""
+    url = "https://api.tradingeconomics.com/calendar"
+    params = {"c": api_key, "format": "json"}
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    return pd.DataFrame(resp.json())
+
+
+api_key = st.text_input("Entrez votre clé API TradingEconomics:")
+
+if api_key:
+    with st.spinner("Récupération des données..."):
+        try:
+            df_calendar = fetch_economic_calendar(api_key)
+            st.dataframe(df_calendar)
+        except Exception as exc:
+            st.error(f"Erreur lors de la récupération des données: {exc}")


### PR DESCRIPTION
## Summary
- integrate requests and pandas to fetch TradingEconomics calendar data
- prompt user for API key and display results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab001b5b88321a87cbfeab537dcde