### PR TITLE
Add personal finance & portfolio tracker PWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log

--- a/data/expenses.json
+++ b/data/expenses.json
@@ -1,0 +1,15 @@
+{
+  "entries": [],
+  "budgets": {
+    "Restaurants": 0,
+    "Courses": 0,
+    "Divertissement": 0,
+    "Transport": 0,
+    "Logement": 0,
+    "Santé": 0,
+    "Vêtements": 0,
+    "Voyages": 0,
+    "Abonnements": 0,
+    "Autre": 0
+  }
+}

--- a/data/portfolio.json
+++ b/data/portfolio.json
@@ -1,0 +1,168 @@
+{
+  "income": 0,
+  "positions": [
+    {
+      "id": "nasdaq100",
+      "ticker": "NASDAQ100",
+      "name": "NASDAQ100 ETF",
+      "type": "ETF",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "soxx",
+      "ticker": "SOXX",
+      "name": "Semiconductors ETF",
+      "type": "ETF",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "nvda",
+      "ticker": "NVDA",
+      "name": "NVIDIA Corporation",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "msft",
+      "ticker": "MSFT",
+      "name": "Microsoft Corporation",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "panw",
+      "ticker": "PANW",
+      "name": "Palo Alto Networks",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "eqix",
+      "ticker": "EQIX",
+      "name": "Equinix",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "rhm",
+      "ticker": "RHM",
+      "name": "Rheinmetall AG",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "lhx",
+      "ticker": "LHX",
+      "name": "L3Harris Technologies",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "wdef",
+      "ticker": "WDEF",
+      "name": "WDEF",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "cprx",
+      "ticker": "CPRX",
+      "name": "Catalyst Biosciences",
+      "type": "Stock",
+      "bucket": "equities",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "krugerrand",
+      "ticker": "KRUG",
+      "name": "Krugerrand",
+      "type": "Coin",
+      "bucket": "gold",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "maple-leaf",
+      "ticker": "MAPLE",
+      "name": "Maple Leaf",
+      "type": "Coin",
+      "bucket": "gold",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "50-ecu",
+      "ticker": "ECU50",
+      "name": "50 ECU",
+      "type": "Coin",
+      "bucket": "gold",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "souverain",
+      "ticker": "SOUV",
+      "name": "Souverain",
+      "type": "Coin",
+      "bucket": "gold",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "20-francs",
+      "ticker": "FR20",
+      "name": "20 Francs",
+      "type": "Coin",
+      "bucket": "gold",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "btc",
+      "ticker": "BTC",
+      "name": "Bitcoin",
+      "type": "Crypto",
+      "bucket": "crypto",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "eth",
+      "ticker": "ETH",
+      "name": "Ethereum",
+      "type": "Crypto",
+      "bucket": "crypto",
+      "currentValue": 0,
+      "costBasis": 0
+    },
+    {
+      "id": "usd-stack",
+      "ticker": "USD",
+      "name": "USD Stack",
+      "type": "Stablecoin",
+      "bucket": "crypto",
+      "currentValue": 0,
+      "costBasis": 0
+    }
+  ],
+  "snapshots": []
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0a0f" />
+    <meta name="description" content="Personal Finance & Portfolio Tracker" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/icon-192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
+    <title>Finance Terminal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2933 @@
+{
+  "name": "finance-tracker-pwa",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "finance-tracker-pwa",
+      "version": "1.0.0",
+      "dependencies": {
+        "chart.js": "^4.4.3",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "react": "^18.3.1",
+        "react-chartjs-2": "^5.2.0",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.1",
+        "concurrently": "^8.2.2",
+        "vite": "^5.3.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "finance-tracker-pwa",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm run server\" \"npm run client\"",
+    "client": "vite",
+    "server": "node server/index.js",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "chart.js": "^4.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "concurrently": "^8.2.2",
+    "vite": "^5.3.1"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0a0a0f"/>
+  <text x="16" y="23" text-anchor="middle" font-family="monospace" font-size="18" font-weight="bold" fill="#00d4ff">₿</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "Finance Terminal",
+  "short_name": "FinTerm",
+  "description": "Personal finance and portfolio tracker",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0f",
+  "theme_color": "#0a0a0f",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,23 @@
+const CACHE = 'finterm-v1'
+const ASSETS = ['/', '/index.html']
+
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).catch(() => {}))
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    )
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', e => {
+  if (e.request.url.includes('/api/')) return
+  e.respondWith(
+    caches.match(e.request).then(cached => cached || fetch(e.request))
+  )
+})

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,120 @@
+const express = require('express')
+const cors = require('cors')
+const fs = require('fs')
+const path = require('path')
+
+const app = express()
+const PORT = 3001
+
+const DATA_DIR = path.join(__dirname, '../data')
+const PORTFOLIO_FILE = path.join(DATA_DIR, 'portfolio.json')
+const EXPENSES_FILE = path.join(DATA_DIR, 'expenses.json')
+
+app.use(cors())
+app.use(express.json())
+
+function readJSON(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function writeJSON(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2))
+}
+
+// Portfolio routes
+app.get('/api/portfolio', (req, res) => {
+  res.json(readJSON(PORTFOLIO_FILE))
+})
+
+app.put('/api/portfolio', (req, res) => {
+  const data = req.body
+  writeJSON(PORTFOLIO_FILE, data)
+  res.json({ ok: true })
+})
+
+app.post('/api/portfolio/positions', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  const position = { ...req.body, id: Date.now().toString() }
+  portfolio.positions.push(position)
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json(position)
+})
+
+app.put('/api/portfolio/positions/:id', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  const idx = portfolio.positions.findIndex(p => p.id === req.params.id)
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  portfolio.positions[idx] = { ...portfolio.positions[idx], ...req.body }
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json(portfolio.positions[idx])
+})
+
+app.delete('/api/portfolio/positions/:id', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  portfolio.positions = portfolio.positions.filter(p => p.id !== req.params.id)
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json({ ok: true })
+})
+
+app.post('/api/portfolio/snapshots', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  const snapshot = req.body
+  const existingIdx = portfolio.snapshots.findIndex(s => s.date === snapshot.date)
+  if (existingIdx >= 0) {
+    portfolio.snapshots[existingIdx] = snapshot
+  } else {
+    portfolio.snapshots.push(snapshot)
+  }
+  portfolio.snapshots.sort((a, b) => a.date.localeCompare(b.date))
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json({ ok: true })
+})
+
+app.delete('/api/portfolio/snapshots/:date', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  portfolio.snapshots = portfolio.snapshots.filter(s => s.date !== req.params.date)
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json({ ok: true })
+})
+
+app.put('/api/portfolio/income', (req, res) => {
+  const portfolio = readJSON(PORTFOLIO_FILE)
+  portfolio.income = req.body.income
+  writeJSON(PORTFOLIO_FILE, portfolio)
+  res.json({ ok: true })
+})
+
+// Expenses routes
+app.get('/api/expenses', (req, res) => {
+  res.json(readJSON(EXPENSES_FILE))
+})
+
+app.post('/api/expenses/entries', (req, res) => {
+  const expenses = readJSON(EXPENSES_FILE)
+  const entry = {
+    id: Date.now().toString(),
+    amount: req.body.amount,
+    date: req.body.date,
+    category: req.body.category,
+    note: req.body.note || '',
+  }
+  expenses.entries.push(entry)
+  writeJSON(EXPENSES_FILE, expenses)
+  res.json(entry)
+})
+
+app.delete('/api/expenses/entries/:id', (req, res) => {
+  const expenses = readJSON(EXPENSES_FILE)
+  expenses.entries = expenses.entries.filter(e => e.id !== req.params.id)
+  writeJSON(EXPENSES_FILE, expenses)
+  res.json({ ok: true })
+})
+
+app.put('/api/expenses/budgets', (req, res) => {
+  const expenses = readJSON(EXPENSES_FILE)
+  expenses.budgets = req.body.budgets
+  writeJSON(EXPENSES_FILE, expenses)
+  res.json({ ok: true })
+})
+
+app.listen(PORT, () => console.log(`API running on http://localhost:${PORT}`))

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { usePortfolio } from './hooks/usePortfolio'
+import { useExpenses } from './hooks/useExpenses'
+import Dashboard from './components/Dashboard'
+import Portfolio from './components/Portfolio'
+import Expenses from './components/Expenses'
+
+const TABS = [
+  { id: 'dashboard', label: 'Vue Globale' },
+  { id: 'portfolio', label: 'Portfolio' },
+  { id: 'expenses', label: 'Dépenses' },
+]
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState('dashboard')
+  const portfolioHook = usePortfolio()
+  const expensesHook = useExpenses()
+
+  const loading = portfolioHook.loading || expensesHook.loading
+
+  return (
+    <>
+      <header className="app-header">
+        <div className="app-header-inner">
+          <div className="app-logo">FIN<span>TERM</span></div>
+          <nav className="main-tabs" role="tablist">
+            {TABS.map(tab => (
+              <button
+                key={tab.id}
+                className={`main-tab${activeTab === tab.id ? ' active' : ''}`}
+                onClick={() => setActiveTab(tab.id)}
+                role="tab"
+                aria-selected={activeTab === tab.id}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+      </header>
+
+      <main className="app-main" role="tabpanel">
+        {loading ? (
+          <div className="empty-state">
+            <span className="empty-state-icon">⟳</span>
+            Chargement…
+          </div>
+        ) : (
+          <>
+            {activeTab === 'dashboard' && (
+              <Dashboard
+                portfolio={portfolioHook.portfolio}
+                expenses={expensesHook.expenses}
+              />
+            )}
+            {activeTab === 'portfolio' && (
+              <Portfolio {...portfolioHook} />
+            )}
+            {activeTab === 'expenses' && (
+              <Expenses {...expensesHook} />
+            )}
+          </>
+        )}
+      </main>
+    </>
+  )
+}

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,0 +1,279 @@
+import React, { useMemo } from 'react'
+import {
+  Chart as ChartJS,
+  ArcElement, LineElement, BarElement,
+  CategoryScale, LinearScale, PointElement,
+  Filler, Tooltip, Legend,
+} from 'chart.js'
+import { Doughnut, Line, Bar } from 'react-chartjs-2'
+import {
+  baseChartOptions, noAxesOptions, BUCKET_COLORS, CATEGORY_COLORS, CATEGORY_EMOJIS,
+  fmtEur, fmtPct, monthLabel, getLast6Months, getCurrentMonthKey, getLastMonthKey, getMonthKey,
+} from '../shared/chartDefaults'
+
+ChartJS.register(ArcElement, LineElement, BarElement, CategoryScale, LinearScale, PointElement, Filler, Tooltip, Legend)
+
+function computeBucketTotals(positions) {
+  return positions.reduce((acc, p) => {
+    acc[p.bucket] = (acc[p.bucket] || 0) + (p.currentValue || 0)
+    return acc
+  }, { equities: 0, gold: 0, crypto: 0 })
+}
+
+function computeMonthlySpending(entries) {
+  return entries.reduce((acc, e) => {
+    const key = getMonthKey(e.date)
+    acc[key] = (acc[key] || 0) + e.amount
+    return acc
+  }, {})
+}
+
+function computeCategoryTotals(entries, monthKey) {
+  return entries
+    .filter(e => getMonthKey(e.date) === monthKey)
+    .reduce((acc, e) => {
+      acc[e.category] = (acc[e.category] || 0) + e.amount
+      return acc
+    }, {})
+}
+
+export default function Dashboard({ portfolio, expenses }) {
+  const positions = portfolio?.positions || []
+  const snapshots = portfolio?.snapshots || []
+  const entries = expenses?.entries || []
+  const income = portfolio?.income || 0
+
+  const buckets = useMemo(() => computeBucketTotals(positions), [positions])
+  const totalPortfolio = Object.values(buckets).reduce((s, v) => s + v, 0)
+
+  const currentMonth = getCurrentMonthKey()
+  const lastMonth = getLastMonthKey()
+  const monthlySpending = useMemo(() => computeMonthlySpending(entries), [entries])
+  const currentSpend = monthlySpending[currentMonth] || 0
+  const lastSpend = monthlySpending[lastMonth] || 0
+  const momDelta = currentSpend - lastSpend
+  const momPct = lastSpend > 0 ? (momDelta / lastSpend) * 100 : 0
+  const netSavings = income > 0 ? income - currentSpend : null
+
+  const catTotals = useMemo(() => computeCategoryTotals(entries, currentMonth), [entries, currentMonth])
+  const top3 = Object.entries(catTotals)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+
+  const last6 = getLast6Months()
+
+  // Allocation donut
+  const donutData = {
+    labels: ['Actions', 'Or', 'Crypto'],
+    datasets: [{
+      data: [buckets.equities, buckets.gold, buckets.crypto],
+      backgroundColor: [BUCKET_COLORS.equities, BUCKET_COLORS.gold, BUCKET_COLORS.crypto],
+      borderColor: '#11111e',
+      borderWidth: 3,
+    }],
+  }
+
+  // Portfolio evolution line
+  const snapshotLabels = snapshots.map(s => monthLabel(s.date))
+  const snapshotValues = snapshots.map(s => s.totalValue)
+  const portfolioLineData = {
+    labels: snapshotLabels.length ? snapshotLabels : ['—'],
+    datasets: [{
+      label: 'Portfolio',
+      data: snapshotValues.length ? snapshotValues : [0],
+      borderColor: BUCKET_COLORS.equities,
+      backgroundColor: 'rgba(0,212,255,0.07)',
+      fill: true,
+      tension: 0.4,
+      pointRadius: 4,
+      pointBackgroundColor: BUCKET_COLORS.equities,
+    }],
+  }
+
+  // Monthly spending trend
+  const spendTrendData = {
+    labels: last6.map(monthLabel),
+    datasets: [{
+      label: 'Dépenses',
+      data: last6.map(k => monthlySpending[k] || 0),
+      borderColor: '#ff4466',
+      backgroundColor: 'rgba(255,68,102,0.07)',
+      fill: true,
+      tension: 0.4,
+      pointRadius: 4,
+      pointBackgroundColor: '#ff4466',
+    }],
+  }
+
+  // Top 3 categories mini bar
+  const top3BarData = {
+    labels: top3.map(([cat]) => `${CATEGORY_EMOJIS[cat] || ''} ${cat}`),
+    datasets: [{
+      label: 'Dépenses',
+      data: top3.map(([, v]) => v),
+      backgroundColor: [CATEGORY_COLORS[0], CATEGORY_COLORS[1], CATEGORY_COLORS[2]],
+      borderRadius: 4,
+    }],
+  }
+
+  const lineOpts = {
+    ...baseChartOptions,
+    plugins: {
+      ...baseChartOptions.plugins,
+      legend: { display: false },
+      tooltip: {
+        ...baseChartOptions.plugins.tooltip,
+        callbacks: { label: ctx => fmtEur(ctx.raw) },
+      },
+    },
+    scales: {
+      x: { ...baseChartOptions.scales.x },
+      y: {
+        ...baseChartOptions.scales.y,
+        ticks: {
+          ...baseChartOptions.scales.y.ticks,
+          callback: v => fmtEur(v),
+        },
+      },
+    },
+  }
+
+  const barOpts = {
+    ...baseChartOptions,
+    indexAxis: 'y',
+    plugins: {
+      ...baseChartOptions.plugins,
+      legend: { display: false },
+      tooltip: {
+        ...baseChartOptions.plugins.tooltip,
+        callbacks: { label: ctx => fmtEur(ctx.raw) },
+      },
+    },
+    scales: {
+      x: {
+        ...baseChartOptions.scales.x,
+        ticks: { ...baseChartOptions.scales.x.ticks, callback: v => fmtEur(v) },
+      },
+      y: { ...baseChartOptions.scales.y },
+    },
+  }
+
+  return (
+    <div>
+      {/* KPI Row */}
+      <div className="kpi-grid section">
+        <div className="kpi-card">
+          <div className="kpi-label">Valeur nette</div>
+          <div className="kpi-value text-accent">{fmtEur(totalPortfolio)}</div>
+          <div className="kpi-delta neutral">Portfolio total</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Dépenses ce mois</div>
+          <div className="kpi-value">{fmtEur(currentSpend)}</div>
+          <div className={`kpi-delta ${momDelta <= 0 ? 'positive' : 'negative'}`}>
+            {momDelta <= 0 ? '↓' : '↑'} {fmtEur(Math.abs(momDelta))} vs mois dernier ({fmtPct(momPct)})
+          </div>
+        </div>
+        {netSavings !== null && (
+          <div className="kpi-card">
+            <div className="kpi-label">Épargne nette</div>
+            <div className={`kpi-value ${netSavings >= 0 ? 'text-green' : 'text-red'}`}>
+              {fmtEur(netSavings)}
+            </div>
+            <div className="kpi-delta neutral">Ce mois</div>
+          </div>
+        )}
+        <div className="kpi-card">
+          <div className="kpi-label">Actions</div>
+          <div className="kpi-value text-accent">{fmtEur(buckets.equities)}</div>
+          <div className="kpi-delta neutral">
+            {totalPortfolio > 0 ? fmtPct(buckets.equities / totalPortfolio * 100).replace('+', '') : '—'}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Or</div>
+          <div className="kpi-value text-gold">{fmtEur(buckets.gold)}</div>
+          <div className="kpi-delta neutral">
+            {totalPortfolio > 0 ? fmtPct(buckets.gold / totalPortfolio * 100).replace('+', '') : '—'}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Crypto</div>
+          <div className="kpi-value" style={{ color: 'var(--purple)' }}>{fmtEur(buckets.crypto)}</div>
+          <div className="kpi-delta neutral">
+            {totalPortfolio > 0 ? fmtPct(buckets.crypto / totalPortfolio * 100).replace('+', '') : '—'}
+          </div>
+        </div>
+      </div>
+
+      {/* Charts Row 1 */}
+      <div className="grid-2 section">
+        <div className="card">
+          <div className="card-title">Allocation</div>
+          <div className="chart-wrap" style={{ maxHeight: 260, display: 'flex', justifyContent: 'center' }}>
+            <div style={{ width: '100%', maxWidth: 280 }}>
+              <Doughnut
+                data={donutData}
+                options={{
+                  ...noAxesOptions,
+                  cutout: '65%',
+                  plugins: {
+                    ...noAxesOptions.plugins,
+                    tooltip: {
+                      ...noAxesOptions.plugins.tooltip,
+                      callbacks: {
+                        label: ctx => {
+                          const v = ctx.raw
+                          const pct = totalPortfolio > 0 ? ((v / totalPortfolio) * 100).toFixed(1) : 0
+                          return ` ${fmtEur(v)} (${pct}%)`
+                        },
+                      },
+                    },
+                  },
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-title">Évolution du portfolio</div>
+          <div className="chart-wrap" style={{ height: 240 }}>
+            {snapshots.length === 0 ? (
+              <div className="empty-state" style={{ padding: '2rem' }}>
+                <span className="empty-state-icon">📈</span>
+                Ajoutez des snapshots dans l'onglet Portfolio
+              </div>
+            ) : (
+              <Line data={portfolioLineData} options={{ ...lineOpts, maintainAspectRatio: false }} />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Charts Row 2 */}
+      <div className="grid-2 section">
+        <div className="card">
+          <div className="card-title">Tendance dépenses (6 mois)</div>
+          <div className="chart-wrap" style={{ height: 220 }}>
+            <Line data={spendTrendData} options={{ ...lineOpts, maintainAspectRatio: false }} />
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-title">Top 3 catégories ce mois</div>
+          <div className="chart-wrap" style={{ height: 220 }}>
+            {top3.length === 0 ? (
+              <div className="empty-state" style={{ padding: '2rem' }}>
+                <span className="empty-state-icon">🍽️</span>
+                Aucune dépense ce mois
+              </div>
+            ) : (
+              <Bar data={top3BarData} options={{ ...barOpts, maintainAspectRatio: false }} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Expenses/index.jsx
+++ b/src/components/Expenses/index.jsx
@@ -1,0 +1,496 @@
+import React, { useState, useMemo, useCallback } from 'react'
+import {
+  Chart as ChartJS, ArcElement, LineElement, BarElement, CategoryScale, LinearScale,
+  PointElement, Tooltip, Legend, Filler,
+} from 'chart.js'
+import { Bar, Line } from 'react-chartjs-2'
+import {
+  baseChartOptions, CATEGORY_COLORS, CATEGORY_EMOJIS, CATEGORIES,
+  fmtEur, fmtPct, monthLabel, getLast6Months, getCurrentMonthKey, getMonthKey,
+} from '../shared/chartDefaults'
+
+ChartJS.register(ArcElement, LineElement, BarElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend, Filler)
+
+const SUB_TABS = [
+  { id: 'summary', label: 'Résumé' },
+  { id: 'charts', label: 'Graphiques' },
+  { id: 'budgets', label: 'Budgets' },
+  { id: 'list', label: 'Liste' },
+]
+
+function useMonthFilter(entries) {
+  const currentMonth = getCurrentMonthKey()
+  const [month, setMonth] = useState(currentMonth)
+  const available = useMemo(() => {
+    const keys = [...new Set(entries.map(e => getMonthKey(e.date)))].sort().reverse()
+    if (!keys.includes(currentMonth)) keys.unshift(currentMonth)
+    return keys
+  }, [entries, currentMonth])
+  const filtered = useMemo(() => entries.filter(e => getMonthKey(e.date) === month), [entries, month])
+  return { month, setMonth, available, filtered }
+}
+
+function AddExpenseModal({ onClose, onAdd }) {
+  const today = new Date().toISOString().split('T')[0]
+  const [form, setForm] = useState({ amount: '', date: today, category: CATEGORIES[0], note: '' })
+  const [loading, setLoading] = useState(false)
+
+  const set = (k, v) => setForm(f => ({ ...f, [k]: v }))
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    if (!form.amount || Number(form.amount) <= 0) return
+    setLoading(true)
+    await onAdd({ ...form, amount: Number(form.amount) })
+    setLoading(false)
+    onClose()
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-title">Nouvelle dépense</div>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+        <form className="modal-form" onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label className="form-label">Montant (€)</label>
+            <input
+              type="number"
+              className="form-input"
+              value={form.amount}
+              onChange={e => set('amount', e.target.value)}
+              placeholder="0"
+              min="0.01"
+              step="0.01"
+              required
+              autoFocus
+            />
+          </div>
+          <div className="form-group">
+            <label className="form-label">Date</label>
+            <input type="date" className="form-input" value={form.date} onChange={e => set('date', e.target.value)} required />
+          </div>
+          <div className="form-group">
+            <label className="form-label">Catégorie</label>
+            <select className="form-select" value={form.category} onChange={e => set('category', e.target.value)}>
+              {CATEGORIES.map(c => (
+                <option key={c} value={c}>{CATEGORY_EMOJIS[c]} {c}</option>
+              ))}
+            </select>
+          </div>
+          <div className="form-group">
+            <label className="form-label">Note (optionnel)</label>
+            <input type="text" className="form-input" value={form.note} onChange={e => set('note', e.target.value)} placeholder="Description…" maxLength={200} />
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" onClick={onClose}>Annuler</button>
+            <button type="submit" className="btn btn-primary" disabled={loading}>
+              {loading ? 'Ajout…' : 'Ajouter'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function Summary({ entries, allEntries }) {
+  const currentMonth = getCurrentMonthKey()
+  const lastMonth = useMemo(() => {
+    const d = new Date()
+    d.setMonth(d.getMonth() - 1)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+  }, [])
+
+  const currentTotal = entries.reduce((s, e) => s + e.amount, 0)
+  const lastEntries = allEntries.filter(e => getMonthKey(e.date) === lastMonth)
+  const lastTotal = lastEntries.reduce((s, e) => s + e.amount, 0)
+  const momDelta = currentTotal - lastTotal
+  const momPct = lastTotal > 0 ? (momDelta / lastTotal) * 100 : 0
+
+  const catTotals = useMemo(() => {
+    return entries.reduce((acc, e) => {
+      acc[e.category] = (acc[e.category] || 0) + e.amount
+      return acc
+    }, {})
+  }, [entries])
+
+  const sorted = Object.entries(catTotals).sort((a, b) => b[1] - a[1])
+
+  return (
+    <div>
+      <div className="kpi-grid section">
+        <div className="kpi-card">
+          <div className="kpi-label">Total ce mois</div>
+          <div className="kpi-value">{fmtEur(currentTotal)}</div>
+          <div className={`kpi-delta ${momDelta <= 0 ? 'positive' : 'negative'}`}>
+            {momDelta <= 0 ? '↓' : '↑'} {fmtEur(Math.abs(momDelta))} vs mois dernier ({fmtPct(momPct)})
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Transactions</div>
+          <div className="kpi-value text-accent">{entries.length}</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Moy. par transaction</div>
+          <div className="kpi-value">{entries.length > 0 ? fmtEur(currentTotal / entries.length) : '—'}</div>
+        </div>
+      </div>
+
+      <div className="section">
+        <div className="section-title">Par catégorie</div>
+        {sorted.length === 0 ? (
+          <div className="empty-state">
+            <span className="empty-state-icon">💳</span>
+            Aucune dépense ce mois
+          </div>
+        ) : (
+          <div className="grid-3">
+            {sorted.map(([cat, val], i) => (
+              <div key={cat} className="card">
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+                  <span style={{ fontSize: '0.9rem' }}>
+                    {CATEGORY_EMOJIS[cat]} <span style={{ fontFamily: 'var(--font-heading)', fontWeight: 600, fontSize: '0.82rem' }}>{cat}</span>
+                  </span>
+                  <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+                    {currentTotal > 0 ? ((val / currentTotal) * 100).toFixed(1) : 0}%
+                  </span>
+                </div>
+                <div style={{ fontSize: '1.2rem', fontWeight: 700, fontFamily: 'var(--font-mono)', marginBottom: '0.4rem', color: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }}>
+                  {fmtEur(val)}
+                </div>
+                <div className="progress-bar">
+                  <div
+                    className="progress-fill ok"
+                    style={{
+                      width: `${currentTotal > 0 ? (val / currentTotal) * 100 : 0}%`,
+                      background: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Charts({ entries }) {
+  const last6 = getLast6Months()
+  const currentMonth = getCurrentMonthKey()
+
+  const currentEntries = useMemo(() => entries.filter(e => getMonthKey(e.date) === currentMonth), [entries, currentMonth])
+
+  const catTotals = useMemo(() => {
+    return currentEntries.reduce((acc, e) => {
+      acc[e.category] = (acc[e.category] || 0) + e.amount
+      return acc
+    }, {})
+  }, [currentEntries])
+
+  const catSorted = Object.entries(catTotals).sort((a, b) => b[1] - a[1])
+
+  const barData = {
+    labels: catSorted.map(([c]) => `${CATEGORY_EMOJIS[c]} ${c}`),
+    datasets: [{
+      label: 'Dépenses',
+      data: catSorted.map(([, v]) => v),
+      backgroundColor: catSorted.map((_, i) => CATEGORY_COLORS[i % CATEGORY_COLORS.length]),
+      borderRadius: 4,
+    }],
+  }
+
+  const monthlyTotals = useMemo(() => {
+    return entries.reduce((acc, e) => {
+      const k = getMonthKey(e.date)
+      acc[k] = (acc[k] || 0) + e.amount
+      return acc
+    }, {})
+  }, [entries])
+
+  const lineData = {
+    labels: last6.map(monthLabel),
+    datasets: [{
+      label: 'Total mensuel',
+      data: last6.map(k => monthlyTotals[k] || 0),
+      borderColor: '#ff4466',
+      backgroundColor: 'rgba(255,68,102,0.08)',
+      fill: true,
+      tension: 0.4,
+      pointRadius: 4,
+      pointBackgroundColor: '#ff4466',
+    }],
+  }
+
+  const stackedDatasets = CATEGORIES.map((cat, i) => ({
+    label: `${CATEGORY_EMOJIS[cat]} ${cat}`,
+    data: last6.map(k => {
+      return entries.filter(e => getMonthKey(e.date) === k && e.category === cat).reduce((s, e) => s + e.amount, 0)
+    }),
+    backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length] + 'cc',
+    fill: true,
+    stack: 'stack',
+    tension: 0.3,
+  }))
+
+  const stackedAreaData = {
+    labels: last6.map(monthLabel),
+    datasets: stackedDatasets,
+  }
+
+  const moneyOpts = {
+    ...baseChartOptions,
+    plugins: {
+      ...baseChartOptions.plugins,
+      tooltip: {
+        ...baseChartOptions.plugins.tooltip,
+        callbacks: { label: ctx => `${ctx.dataset.label}: ${fmtEur(ctx.raw)}` },
+      },
+    },
+    scales: {
+      x: { ...baseChartOptions.scales.x },
+      y: {
+        ...baseChartOptions.scales.y,
+        stacked: false,
+        ticks: { ...baseChartOptions.scales.y.ticks, callback: v => fmtEur(v) },
+      },
+    },
+  }
+
+  const stackedOpts = {
+    ...moneyOpts,
+    scales: {
+      x: { ...baseChartOptions.scales.x, stacked: true },
+      y: { ...moneyOpts.scales.y, stacked: true },
+    },
+  }
+
+  return (
+    <div>
+      <div className="grid-2 section">
+        <div className="card">
+          <div className="card-title">Par catégorie (ce mois)</div>
+          <div style={{ height: 280 }}>
+            {catSorted.length === 0 ? (
+              <div className="empty-state" style={{ padding: '2rem' }}>Aucune dépense ce mois</div>
+            ) : (
+              <Bar data={barData} options={{ ...moneyOpts, indexAxis: 'y', maintainAspectRatio: false }} />
+            )}
+          </div>
+        </div>
+        <div className="card">
+          <div className="card-title">Tendance mensuelle (6 mois)</div>
+          <div style={{ height: 280 }}>
+            <Line data={lineData} options={{ ...moneyOpts, maintainAspectRatio: false }} />
+          </div>
+        </div>
+      </div>
+      <div className="card section">
+        <div className="card-title">Répartition par catégorie (6 mois)</div>
+        <div style={{ height: 300 }}>
+          <Bar data={stackedAreaData} options={{ ...stackedOpts, maintainAspectRatio: false }} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Budgets({ expenses, onUpdateBudgets }) {
+  const entries = expenses?.entries || []
+  const budgets = expenses?.budgets || {}
+  const currentMonth = getCurrentMonthKey()
+
+  const [localBudgets, setLocalBudgets] = useState(() => ({ ...budgets }))
+  const [saving, setSaving] = useState(false)
+
+  const catTotals = useMemo(() => {
+    return entries
+      .filter(e => getMonthKey(e.date) === currentMonth)
+      .reduce((acc, e) => {
+        acc[e.category] = (acc[e.category] || 0) + e.amount
+        return acc
+      }, {})
+  }, [entries, currentMonth])
+
+  const handleSave = async () => {
+    setSaving(true)
+    await onUpdateBudgets(localBudgets)
+    setSaving(false)
+  }
+
+  return (
+    <div>
+      <div className="section">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+          <div className="section-title" style={{ marginBottom: 0 }}>Limites budgétaires (ce mois)</div>
+          <button className="btn btn-primary btn-sm" onClick={handleSave} disabled={saving}>
+            {saving ? 'Sauvegarde…' : '💾 Sauvegarder'}
+          </button>
+        </div>
+        <div className="grid-2">
+          {CATEGORIES.map((cat, i) => {
+            const spent = catTotals[cat] || 0
+            const budget = Number(localBudgets[cat]) || 0
+            const pct = budget > 0 ? Math.min((spent / budget) * 100, 100) : 0
+            const over = budget > 0 && spent > budget
+            const fillClass = over ? 'over' : pct > 75 ? 'warn' : 'ok'
+            return (
+              <div key={cat} className="card">
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+                  <span style={{ fontFamily: 'var(--font-heading)', fontWeight: 600, fontSize: '0.85rem' }}>
+                    {CATEGORY_EMOJIS[cat]} {cat}
+                  </span>
+                  {over && <span className="badge negative">DÉPASSÉ</span>}
+                </div>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.5rem' }}>
+                  <span style={{ fontSize: '0.9rem', fontFamily: 'var(--font-mono)', fontWeight: 700, color: over ? 'var(--red)' : CATEGORY_COLORS[i % CATEGORY_COLORS.length] }}>
+                    {fmtEur(spent)}
+                  </span>
+                  <span style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>/</span>
+                  <input
+                    type="number"
+                    className="form-input"
+                    style={{ maxWidth: 100, padding: '0.2rem 0.5rem', fontSize: '0.8rem' }}
+                    value={localBudgets[cat] || ''}
+                    onChange={e => setLocalBudgets(b => ({ ...b, [cat]: e.target.value }))}
+                    placeholder="Budget"
+                    min="0"
+                    step="10"
+                  />
+                </div>
+                <div className="progress-bar">
+                  <div
+                    className={`progress-fill ${fillClass}`}
+                    style={{ width: `${budget > 0 ? pct : 0}%` }}
+                  />
+                </div>
+                {budget > 0 && (
+                  <div style={{ fontSize: '0.7rem', color: over ? 'var(--red)' : 'var(--text-muted)', marginTop: '0.3rem', fontFamily: 'var(--font-mono)' }}>
+                    {over ? `Dépassement de ${fmtEur(spent - budget)}` : `${pct.toFixed(0)}% utilisé — reste ${fmtEur(budget - spent)}`}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ExpenseList({ entries, onDelete }) {
+  const [catFilter, setCatFilter] = useState('')
+  const { month, setMonth, available, filtered } = useMonthFilter(entries)
+
+  const displayed = catFilter ? filtered.filter(e => e.category === catFilter) : filtered
+  const sorted = [...displayed].sort((a, b) => b.date.localeCompare(a.date))
+
+  return (
+    <div>
+      <div className="filter-row">
+        <div className="form-group" style={{ flex: '0 0 auto' }}>
+          <select className="form-select" value={month} onChange={e => setMonth(e.target.value)} style={{ width: 'auto' }}>
+            {available.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+        </div>
+        <div className="form-group" style={{ flex: '0 0 auto' }}>
+          <select className="form-select" value={catFilter} onChange={e => setCatFilter(e.target.value)} style={{ width: 'auto' }}>
+            <option value="">Toutes catégories</option>
+            {CATEGORIES.map(c => <option key={c} value={c}>{CATEGORY_EMOJIS[c]} {c}</option>)}
+          </select>
+        </div>
+        <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', alignSelf: 'flex-end', paddingBottom: '0.5rem' }}>
+          {sorted.length} dépense{sorted.length > 1 ? 's' : ''} · {fmtEur(sorted.reduce((s, e) => s + e.amount, 0))}
+        </div>
+      </div>
+
+      {sorted.length === 0 ? (
+        <div className="empty-state">
+          <span className="empty-state-icon">📋</span>
+          Aucune dépense pour cette période
+        </div>
+      ) : (
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Catégorie</th>
+                <th className="num">Montant</th>
+                <th>Note</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map(e => (
+                <tr key={e.id}>
+                  <td style={{ color: 'var(--text-secondary)', fontSize: '0.78rem', fontFamily: 'var(--font-mono)' }}>{e.date}</td>
+                  <td>
+                    <span>{CATEGORY_EMOJIS[e.category]} </span>
+                    <span style={{ fontSize: '0.8rem', fontFamily: 'var(--font-heading)', fontWeight: 600 }}>{e.category}</span>
+                  </td>
+                  <td className="num" style={{ fontWeight: 700, color: 'var(--red)' }}>−{fmtEur(e.amount)}</td>
+                  <td style={{ color: 'var(--text-secondary)', fontSize: '0.78rem', maxWidth: 200 }}>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block' }}>
+                      {e.note || '—'}
+                    </span>
+                  </td>
+                  <td>
+                    <button className="btn btn-ghost btn-sm" onClick={() => onDelete(e.id)} title="Supprimer">✕</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function Expenses({ expenses, addEntry, deleteEntry, updateBudgets }) {
+  const [sub, setSub] = useState('summary')
+  const [showModal, setShowModal] = useState(false)
+
+  const entries = expenses?.entries || []
+  const currentMonth = getCurrentMonthKey()
+  const currentEntries = useMemo(() => entries.filter(e => getMonthKey(e.date) === currentMonth), [entries, currentMonth])
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+        <div className="sub-tabs" style={{ flex: 1, marginBottom: 0, borderBottom: 'none' }}>
+          {SUB_TABS.map(t => (
+            <button
+              key={t.id}
+              className={`sub-tab${sub === t.id ? ' active' : ''}`}
+              onClick={() => setSub(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <button className="btn btn-primary btn-sm" style={{ marginLeft: '1rem' }} onClick={() => setShowModal(true)}>
+          + Dépense
+        </button>
+      </div>
+      <div style={{ borderBottom: '1px solid var(--border)', marginBottom: '1.5rem' }} />
+
+      {sub === 'summary' && <Summary entries={currentEntries} allEntries={entries} />}
+      {sub === 'charts' && <Charts entries={entries} />}
+      {sub === 'budgets' && <Budgets expenses={expenses} onUpdateBudgets={updateBudgets} />}
+      {sub === 'list' && <ExpenseList entries={entries} onDelete={deleteEntry} />}
+
+      {showModal && (
+        <AddExpenseModal
+          onClose={() => setShowModal(false)}
+          onAdd={addEntry}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/Portfolio/Edition.jsx
+++ b/src/components/Portfolio/Edition.jsx
@@ -1,0 +1,227 @@
+import React, { useState, useCallback } from 'react'
+import { fmtEur } from '../shared/chartDefaults'
+
+const BUCKETS = ['equities', 'gold', 'crypto']
+const BUCKET_LABELS = { equities: 'Actions', gold: 'Or', crypto: 'Crypto' }
+const TYPES = ['Stock', 'ETF', 'Coin', 'Crypto', 'Stablecoin', 'Autre']
+
+const NEW_POSITION_DEFAULTS = {
+  ticker: '',
+  name: '',
+  type: 'Stock',
+  bucket: 'equities',
+  currentValue: '',
+  costBasis: '',
+}
+
+export default function Edition({ portfolio, onSave, onAdd, onDelete, setIncome }) {
+  const positions = portfolio?.positions || []
+  const [edits, setEdits] = useState({})
+  const [saving, setSaving] = useState(false)
+  const [newPos, setNewPos] = useState(null)
+  const [income, setIncomeLocal] = useState(portfolio?.income || 0)
+  const [savingIncome, setSavingIncome] = useState(false)
+
+  const getValue = (id, field, fallback) => {
+    if (edits[id]?.[field] !== undefined) return edits[id][field]
+    return fallback ?? ''
+  }
+
+  const setField = (id, field, value) => {
+    setEdits(prev => ({
+      ...prev,
+      [id]: { ...prev[id], [field]: value },
+    }))
+  }
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    const updated = {
+      ...portfolio,
+      positions: positions.map(p => ({
+        ...p,
+        currentValue: edits[p.id]?.currentValue !== undefined
+          ? Number(edits[p.id].currentValue) : p.currentValue,
+        costBasis: edits[p.id]?.costBasis !== undefined
+          ? Number(edits[p.id].costBasis) : p.costBasis,
+      })),
+    }
+    await onSave(updated)
+    setEdits({})
+    setSaving(false)
+  }, [edits, positions, portfolio, onSave])
+
+  const handleAddPosition = useCallback(async () => {
+    if (!newPos.ticker || !newPos.name) return
+    await onAdd({
+      ticker: newPos.ticker.toUpperCase(),
+      name: newPos.name,
+      type: newPos.type,
+      bucket: newPos.bucket,
+      currentValue: Number(newPos.currentValue) || 0,
+      costBasis: Number(newPos.costBasis) || 0,
+    })
+    setNewPos(null)
+  }, [newPos, onAdd])
+
+  const handleSaveIncome = useCallback(async () => {
+    setSavingIncome(true)
+    await setIncome(Number(income) || 0)
+    setSavingIncome(false)
+  }, [income, setIncome])
+
+  const grouped = BUCKETS.reduce((acc, b) => {
+    acc[b] = positions.filter(p => p.bucket === b)
+    return acc
+  }, {})
+
+  return (
+    <div>
+      {/* Income */}
+      <div className="section">
+        <div className="section-title">Revenu mensuel</div>
+        <div className="card" style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+          <div className="form-group" style={{ flex: 1, minWidth: 160 }}>
+            <label className="form-label">Revenu net mensuel (€)</label>
+            <input
+              type="number"
+              className="form-input"
+              value={income}
+              onChange={e => setIncomeLocal(e.target.value)}
+              min="0"
+              step="100"
+            />
+          </div>
+          <button className="btn btn-secondary btn-sm" onClick={handleSaveIncome} disabled={savingIncome}>
+            {savingIncome ? 'Sauvegarde…' : 'Sauvegarder'}
+          </button>
+        </div>
+      </div>
+
+      {/* Positions by bucket */}
+      {BUCKETS.map(bucket => (
+        <div key={bucket} className="section">
+          <div className="section-title">{BUCKET_LABELS[bucket]}</div>
+          <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+            <div style={{ overflowX: 'auto' }}>
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>Ticker / Nom</th>
+                    <th>Type</th>
+                    <th className="num">Valeur actuelle (€)</th>
+                    <th className="num">PRU (€)</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {grouped[bucket].map(p => (
+                    <tr key={p.id}>
+                      <td>
+                        <div style={{ fontWeight: 700, fontSize: '0.85rem', color: 'var(--accent)' }}>{p.ticker}</div>
+                        <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{p.name}</div>
+                      </td>
+                      <td>
+                        <select
+                          className="form-select"
+                          style={{ padding: '0.3rem 1.5rem 0.3rem 0.5rem', fontSize: '0.75rem', width: 'auto' }}
+                          value={getValue(p.id, 'type', p.type)}
+                          onChange={e => setField(p.id, 'type', e.target.value)}
+                        >
+                          {TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                        </select>
+                      </td>
+                      <td className="num">
+                        <input
+                          type="number"
+                          className="form-input"
+                          style={{ textAlign: 'right', maxWidth: 140 }}
+                          value={getValue(p.id, 'currentValue', p.currentValue)}
+                          onChange={e => setField(p.id, 'currentValue', e.target.value)}
+                          min="0"
+                          step="1"
+                        />
+                      </td>
+                      <td className="num">
+                        <input
+                          type="number"
+                          className="form-input"
+                          style={{ textAlign: 'right', maxWidth: 140 }}
+                          value={getValue(p.id, 'costBasis', p.costBasis)}
+                          onChange={e => setField(p.id, 'costBasis', e.target.value)}
+                          min="0"
+                          step="1"
+                        />
+                      </td>
+                      <td>
+                        <button className="btn btn-ghost btn-sm" onClick={() => onDelete(p.id)} title="Supprimer">✕</button>
+                      </td>
+                    </tr>
+                  ))}
+                  {grouped[bucket].length === 0 && (
+                    <tr>
+                      <td colSpan={5} style={{ textAlign: 'center', color: 'var(--text-muted)', padding: '1rem' }}>
+                        Aucune position dans ce bucket
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {/* Save button */}
+      <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1.5rem' }}>
+        <button className="btn btn-primary" onClick={handleSave} disabled={saving}>
+          {saving ? 'Sauvegarde…' : '💾 Sauvegarder les positions'}
+        </button>
+        <button className="btn btn-secondary" onClick={() => setNewPos({ ...NEW_POSITION_DEFAULTS })}>
+          + Ajouter une position
+        </button>
+      </div>
+
+      {/* Add position form */}
+      {newPos && (
+        <div className="card section">
+          <div className="card-title">Nouvelle position</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.75rem' }}>
+            <div className="form-group">
+              <label className="form-label">Ticker</label>
+              <input className="form-input" value={newPos.ticker} onChange={e => setNewPos(p => ({ ...p, ticker: e.target.value }))} placeholder="AAPL" />
+            </div>
+            <div className="form-group">
+              <label className="form-label">Nom</label>
+              <input className="form-input" value={newPos.name} onChange={e => setNewPos(p => ({ ...p, name: e.target.value }))} placeholder="Apple Inc." />
+            </div>
+            <div className="form-group">
+              <label className="form-label">Type</label>
+              <select className="form-select" value={newPos.type} onChange={e => setNewPos(p => ({ ...p, type: e.target.value }))}>
+                {TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+            <div className="form-group">
+              <label className="form-label">Bucket</label>
+              <select className="form-select" value={newPos.bucket} onChange={e => setNewPos(p => ({ ...p, bucket: e.target.value }))}>
+                {BUCKETS.map(b => <option key={b} value={b}>{BUCKET_LABELS[b]}</option>)}
+              </select>
+            </div>
+            <div className="form-group">
+              <label className="form-label">Valeur actuelle (€)</label>
+              <input type="number" className="form-input" value={newPos.currentValue} onChange={e => setNewPos(p => ({ ...p, currentValue: e.target.value }))} min="0" />
+            </div>
+            <div className="form-group">
+              <label className="form-label">PRU (€)</label>
+              <input type="number" className="form-input" value={newPos.costBasis} onChange={e => setNewPos(p => ({ ...p, costBasis: e.target.value }))} min="0" />
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1rem' }}>
+            <button className="btn btn-primary btn-sm" onClick={handleAddPosition}>Ajouter</button>
+            <button className="btn btn-secondary btn-sm" onClick={() => setNewPos(null)}>Annuler</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Portfolio/Performance.jsx
+++ b/src/components/Portfolio/Performance.jsx
@@ -1,0 +1,217 @@
+import React, { useState, useMemo } from 'react'
+import {
+  Chart as ChartJS, LineElement, BarElement, CategoryScale, LinearScale,
+  PointElement, Tooltip, Legend, Filler,
+} from 'chart.js'
+import { Line, Bar } from 'react-chartjs-2'
+import { BUCKET_COLORS, baseChartOptions, fmtEur, fmtPct, monthLabel } from '../shared/chartDefaults'
+
+ChartJS.register(LineElement, BarElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend, Filler)
+
+export default function Performance({ portfolio, onAddSnapshot, onDeleteSnapshot }) {
+  const positions = portfolio?.positions || []
+  const snapshots = portfolio?.snapshots || []
+
+  const totalValue = positions.reduce((s, p) => s + (p.currentValue || 0), 0)
+  const totalCost = positions.reduce((s, p) => s + (p.costBasis || 0), 0)
+  const totalPnl = totalValue - totalCost
+  const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0
+
+  const bucketValues = positions.reduce((acc, p) => {
+    acc[p.bucket] = (acc[p.bucket] || 0) + (p.currentValue || 0)
+    return acc
+  }, { equities: 0, gold: 0, crypto: 0 })
+
+  const today = new Date().toISOString().split('T')[0].slice(0, 7)
+  const [snapDate, setSnapDate] = useState(today)
+  const [adding, setAdding] = useState(false)
+
+  const momDelta = useMemo(() => {
+    if (snapshots.length < 2) return null
+    const last = snapshots[snapshots.length - 1]
+    const prev = snapshots[snapshots.length - 2]
+    const delta = last.totalValue - prev.totalValue
+    const pct = prev.totalValue > 0 ? (delta / prev.totalValue) * 100 : 0
+    return { delta, pct }
+  }, [snapshots])
+
+  const labels = snapshots.map(s => monthLabel(s.date))
+
+  const lineData = {
+    labels,
+    datasets: [{
+      label: 'Total',
+      data: snapshots.map(s => s.totalValue),
+      borderColor: BUCKET_COLORS.equities,
+      backgroundColor: 'rgba(0,212,255,0.07)',
+      fill: true,
+      tension: 0.4,
+      pointRadius: 4,
+      pointBackgroundColor: BUCKET_COLORS.equities,
+    }],
+  }
+
+  const stackedBarData = {
+    labels,
+    datasets: [
+      {
+        label: 'Actions',
+        data: snapshots.map(s => s.buckets?.equities || 0),
+        backgroundColor: BUCKET_COLORS.equities,
+        stack: 'portfolio',
+      },
+      {
+        label: 'Or',
+        data: snapshots.map(s => s.buckets?.gold || 0),
+        backgroundColor: BUCKET_COLORS.gold,
+        stack: 'portfolio',
+      },
+      {
+        label: 'Crypto',
+        data: snapshots.map(s => s.buckets?.crypto || 0),
+        backgroundColor: BUCKET_COLORS.crypto,
+        stack: 'portfolio',
+      },
+    ],
+  }
+
+  const chartOpts = {
+    ...baseChartOptions,
+    plugins: {
+      ...baseChartOptions.plugins,
+      tooltip: {
+        ...baseChartOptions.plugins.tooltip,
+        callbacks: { label: ctx => `${ctx.dataset.label}: ${fmtEur(ctx.raw)}` },
+      },
+    },
+    scales: {
+      x: { ...baseChartOptions.scales.x },
+      y: {
+        ...baseChartOptions.scales.y,
+        ticks: { ...baseChartOptions.scales.y.ticks, callback: v => fmtEur(v) },
+      },
+    },
+  }
+
+  const handleAddSnapshot = async () => {
+    setAdding(true)
+    await onAddSnapshot({
+      date: snapDate,
+      totalValue,
+      buckets: { ...bucketValues },
+    })
+    setAdding(false)
+  }
+
+  return (
+    <div>
+      {/* KPIs */}
+      <div className="kpi-grid section">
+        <div className="kpi-card">
+          <div className="kpi-label">P&L total</div>
+          <div className={`kpi-value ${totalPnl >= 0 ? 'text-green' : 'text-red'}`}>{fmtEur(totalPnl)}</div>
+          <div className={`kpi-delta ${totalPnl >= 0 ? 'positive' : 'negative'}`}>{fmtPct(totalPnlPct)}</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Delta MoM</div>
+          <div className={`kpi-value ${momDelta === null ? '' : momDelta.delta >= 0 ? 'text-green' : 'text-red'}`}>
+            {momDelta ? fmtEur(momDelta.delta) : '—'}
+          </div>
+          <div className={`kpi-delta ${momDelta === null ? 'neutral' : momDelta.delta >= 0 ? 'positive' : 'negative'}`}>
+            {momDelta ? fmtPct(momDelta.pct) : 'Pas assez de snapshots'}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Snapshots</div>
+          <div className="kpi-value text-accent">{snapshots.length}</div>
+          <div className="kpi-delta neutral">enregistrements</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">Valeur actuelle</div>
+          <div className="kpi-value text-accent">{fmtEur(totalValue)}</div>
+        </div>
+      </div>
+
+      {/* Charts */}
+      {snapshots.length > 0 && (
+        <div className="grid-2 section">
+          <div className="card">
+            <div className="card-title">Évolution portfolio</div>
+            <div style={{ height: 240 }}>
+              <Line data={lineData} options={{ ...chartOpts, maintainAspectRatio: false }} />
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Par bucket (empilé)</div>
+            <div style={{ height: 240 }}>
+              <Bar data={stackedBarData} options={{ ...chartOpts, maintainAspectRatio: false }} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Snapshot manager */}
+      <div className="section">
+        <div className="section-title">Snapshots</div>
+        <div className="card" style={{ marginBottom: '1rem' }}>
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-end', flexWrap: 'wrap', marginBottom: '1rem' }}>
+            <div className="form-group">
+              <label className="form-label">Date du snapshot (YYYY-MM)</label>
+              <input
+                type="month"
+                className="form-input"
+                value={snapDate}
+                onChange={e => setSnapDate(e.target.value)}
+                style={{ maxWidth: 200 }}
+              />
+            </div>
+            <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', paddingBottom: '0.1rem' }}>
+              Valeur: <strong style={{ color: 'var(--accent)' }}>{fmtEur(totalValue)}</strong>
+              <br />
+              <span style={{ fontSize: '0.7rem' }}>Actions: {fmtEur(bucketValues.equities)} · Or: {fmtEur(bucketValues.gold)} · Crypto: {fmtEur(bucketValues.crypto)}</span>
+            </div>
+            <button className="btn btn-primary btn-sm" onClick={handleAddSnapshot} disabled={adding}>
+              {adding ? 'Ajout…' : '+ Ajouter snapshot'}
+            </button>
+          </div>
+        </div>
+
+        {snapshots.length === 0 ? (
+          <div className="empty-state">
+            <span className="empty-state-icon">📸</span>
+            Aucun snapshot. Ajoutez-en un pour commencer le suivi.
+          </div>
+        ) : (
+          <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th className="num">Valeur totale</th>
+                  <th className="num">Actions</th>
+                  <th className="num">Or</th>
+                  <th className="num">Crypto</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...snapshots].reverse().map(s => (
+                  <tr key={s.date}>
+                    <td style={{ fontFamily: 'var(--font-mono)', color: 'var(--accent)' }}>{s.date}</td>
+                    <td className="num" style={{ fontWeight: 700 }}>{fmtEur(s.totalValue)}</td>
+                    <td className="num">{fmtEur(s.buckets?.equities)}</td>
+                    <td className="num">{fmtEur(s.buckets?.gold)}</td>
+                    <td className="num">{fmtEur(s.buckets?.crypto)}</td>
+                    <td>
+                      <button className="btn btn-ghost btn-sm" onClick={() => onDeleteSnapshot(s.date)} title="Supprimer">✕</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Portfolio/PortfolioGlobale.jsx
+++ b/src/components/Portfolio/PortfolioGlobale.jsx
@@ -1,0 +1,192 @@
+import React, { useMemo } from 'react'
+import { Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js'
+import { Doughnut, Bar } from 'react-chartjs-2'
+import { BUCKET_COLORS, noAxesOptions, baseChartOptions, fmtEur, fmtPct } from '../shared/chartDefaults'
+
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend)
+
+const BUCKET_LABELS = { equities: 'Actions', gold: 'Or', crypto: 'Crypto' }
+
+export default function PortfolioGlobale({ portfolio }) {
+  const positions = portfolio?.positions || []
+
+  const buckets = useMemo(() => {
+    return positions.reduce((acc, p) => {
+      acc[p.bucket] = (acc[p.bucket] || 0) + (p.currentValue || 0)
+      return acc
+    }, { equities: 0, gold: 0, crypto: 0 })
+  }, [positions])
+
+  const costBuckets = useMemo(() => {
+    return positions.reduce((acc, p) => {
+      acc[p.bucket] = (acc[p.bucket] || 0) + (p.costBasis || 0)
+      return acc
+    }, { equities: 0, gold: 0, crypto: 0 })
+  }, [positions])
+
+  const totalValue = Object.values(buckets).reduce((s, v) => s + v, 0)
+  const totalCost = Object.values(costBuckets).reduce((s, v) => s + v, 0)
+  const totalPnl = totalValue - totalCost
+  const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0
+
+  const donutData = {
+    labels: ['Actions', 'Or', 'Crypto'],
+    datasets: [{
+      data: [buckets.equities, buckets.gold, buckets.crypto],
+      backgroundColor: [BUCKET_COLORS.equities, BUCKET_COLORS.gold, BUCKET_COLORS.crypto],
+      borderColor: '#11111e',
+      borderWidth: 3,
+    }],
+  }
+
+  const barData = {
+    labels: Object.entries(BUCKET_LABELS).map(([k, v]) => v),
+    datasets: [{
+      data: [buckets.equities, buckets.gold, buckets.crypto],
+      backgroundColor: [BUCKET_COLORS.equities, BUCKET_COLORS.gold, BUCKET_COLORS.crypto],
+      borderRadius: 4,
+    }],
+  }
+
+  const barOpts = {
+    ...baseChartOptions,
+    plugins: {
+      ...baseChartOptions.plugins,
+      legend: { display: false },
+      tooltip: {
+        ...baseChartOptions.plugins.tooltip,
+        callbacks: { label: ctx => fmtEur(ctx.raw) },
+      },
+    },
+    scales: {
+      x: { ...baseChartOptions.scales.x },
+      y: {
+        ...baseChartOptions.scales.y,
+        ticks: { ...baseChartOptions.scales.y.ticks, callback: v => fmtEur(v) },
+      },
+    },
+  }
+
+  return (
+    <div>
+      {/* Header KPIs */}
+      <div className="kpi-grid section">
+        <div className="kpi-card">
+          <div className="kpi-label">Valeur totale</div>
+          <div className="kpi-value text-accent">{fmtEur(totalValue)}</div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">P&L total</div>
+          <div className={`kpi-value ${totalPnl >= 0 ? 'text-green' : 'text-red'}`}>{fmtEur(totalPnl)}</div>
+          <div className={`kpi-delta ${totalPnl >= 0 ? 'positive' : 'negative'}`}>
+            {totalPnl >= 0 ? '↑' : '↓'} {fmtPct(totalPnlPct)}
+          </div>
+        </div>
+        <div className="kpi-card">
+          <div className="kpi-label">PRU total</div>
+          <div className="kpi-value">{fmtEur(totalCost)}</div>
+        </div>
+      </div>
+
+      {/* Allocation */}
+      <div className="section">
+        <div className="section-title">Allocation</div>
+        <div className="card" style={{ marginBottom: '0.75rem' }}>
+          <div className="alloc-bar" style={{ height: 12 }}>
+            {['equities', 'gold', 'crypto'].map(b => (
+              <div
+                key={b}
+                className={`alloc-seg bg-${b}`}
+                style={{ flex: totalValue > 0 ? buckets[b] / totalValue : 0 }}
+              />
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: '1.5rem', marginTop: '0.75rem', flexWrap: 'wrap' }}>
+            {['equities', 'gold', 'crypto'].map(b => (
+              <div key={b} style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                <div style={{ width: 8, height: 8, borderRadius: 2, background: BUCKET_COLORS[b] }} />
+                <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', fontFamily: 'var(--font-heading)' }}>
+                  {BUCKET_LABELS[b]}
+                </span>
+                <span style={{ fontSize: '0.75rem', fontFamily: 'var(--font-mono)' }}>
+                  {fmtEur(buckets[b])}
+                </span>
+                <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary)' }}>
+                  {totalValue > 0 ? `(${((buckets[b] / totalValue) * 100).toFixed(1)}%)` : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Charts */}
+      <div className="grid-2 section">
+        <div className="card">
+          <div className="card-title">Répartition</div>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ width: '100%', maxWidth: 260 }}>
+              <Doughnut
+                data={donutData}
+                options={{
+                  ...noAxesOptions,
+                  cutout: '65%',
+                  plugins: {
+                    ...noAxesOptions.plugins,
+                    tooltip: {
+                      ...noAxesOptions.plugins.tooltip,
+                      callbacks: {
+                        label: ctx => {
+                          const pct = totalValue > 0 ? ((ctx.raw / totalValue) * 100).toFixed(1) : 0
+                          return ` ${fmtEur(ctx.raw)} (${pct}%)`
+                        },
+                      },
+                    },
+                  },
+                }}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="card">
+          <div className="card-title">Par bucket</div>
+          <div style={{ height: 220 }}>
+            <Bar data={barData} options={{ ...barOpts, maintainAspectRatio: false }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Bucket cards */}
+      <div className="section">
+        <div className="section-title">Buckets</div>
+        <div className="grid-3">
+          {[
+            { key: 'equities', label: 'Actions', color: 'var(--accent)' },
+            { key: 'gold', label: 'Or', color: 'var(--gold)' },
+            { key: 'crypto', label: 'Crypto', color: 'var(--purple)' },
+          ].map(({ key, label, color }) => {
+            const val = buckets[key]
+            const cost = costBuckets[key]
+            const pnl = val - cost
+            const pnlPct = cost > 0 ? (pnl / cost) * 100 : 0
+            const pct = totalValue > 0 ? (val / totalValue) * 100 : 0
+            return (
+              <div key={key} className="card" style={{ borderLeft: `3px solid ${color}` }}>
+                <div className="card-title" style={{ color }}>{label}</div>
+                <div style={{ fontSize: '1.4rem', fontWeight: 700, fontFamily: 'var(--font-mono)', marginBottom: '0.25rem' }}>
+                  {fmtEur(val)}
+                </div>
+                <div style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', marginBottom: '0.5rem' }}>
+                  {pct.toFixed(1)}% du total
+                </div>
+                <div className={`badge ${pnl >= 0 ? 'positive' : 'negative'}`}>
+                  {pnl >= 0 ? '↑' : '↓'} {fmtEur(pnl)} ({fmtPct(pnlPct)})
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Portfolio/Positions.jsx
+++ b/src/components/Portfolio/Positions.jsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { fmtEur, fmtPct } from '../shared/chartDefaults'
+
+const BUCKET_ORDER = ['equities', 'gold', 'crypto']
+const BUCKET_LABELS = { equities: '📈 Actions', gold: '🥇 Or', crypto: '₿ Crypto' }
+
+function TypeBadge({ type }) {
+  const cls = {
+    ETF: 'type-etf',
+    Stock: 'type-stock',
+    Crypto: 'type-crypto',
+    Coin: 'type-coin',
+    Stablecoin: 'type-stablecoin',
+  }[type] || 'neutral'
+  return <span className={`badge ${cls}`}>{type}</span>
+}
+
+function PnlCell({ value, cost }) {
+  const pnl = value - cost
+  const pnlPct = cost > 0 ? (pnl / cost) * 100 : null
+  const cls = pnl >= 0 ? 'text-green' : 'text-red'
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.1rem' }}>
+      <span className={cls} style={{ fontSize: '0.82rem', fontFamily: 'var(--font-mono)' }}>
+        {pnl >= 0 ? '+' : ''}{fmtEur(pnl)}
+      </span>
+      {pnlPct !== null && (
+        <span style={{ fontSize: '0.7rem', color: pnl >= 0 ? 'var(--green)' : 'var(--red)', opacity: 0.8 }}>
+          {fmtPct(pnlPct)}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default function Positions({ portfolio }) {
+  const positions = portfolio?.positions || []
+
+  const grouped = BUCKET_ORDER.reduce((acc, b) => {
+    acc[b] = positions.filter(p => p.bucket === b)
+    return acc
+  }, {})
+
+  if (positions.length === 0) {
+    return (
+      <div className="empty-state">
+        <span className="empty-state-icon">📊</span>
+        Aucune position. Ajoutez-en dans l'onglet Édition.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {BUCKET_ORDER.map(bucket => {
+        const group = grouped[bucket]
+        if (group.length === 0) return null
+        const bucketTotal = group.reduce((s, p) => s + (p.currentValue || 0), 0)
+        return (
+          <div key={bucket} className="section">
+            <div className="section-title">
+              {BUCKET_LABELS[bucket]}
+              <span style={{ marginLeft: 'auto', fontSize: '0.82rem', color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>
+                {fmtEur(bucketTotal)}
+              </span>
+            </div>
+            <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+              <div style={{ overflowX: 'auto' }}>
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th>Ticker</th>
+                      <th>Nom</th>
+                      <th>Type</th>
+                      <th className="num">Valeur</th>
+                      <th className="num">PRU</th>
+                      <th className="num">P&L</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.map(p => (
+                      <tr key={p.id}>
+                        <td style={{ fontWeight: 700, color: 'var(--accent)' }}>{p.ticker}</td>
+                        <td style={{ color: 'var(--text-secondary)', fontSize: '0.8rem' }}>{p.name}</td>
+                        <td><TypeBadge type={p.type} /></td>
+                        <td className="num">{fmtEur(p.currentValue)}</td>
+                        <td className="num" style={{ color: 'var(--text-secondary)' }}>{fmtEur(p.costBasis)}</td>
+                        <td className="num">
+                          <PnlCell value={p.currentValue || 0} cost={p.costBasis || 0} />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Portfolio/index.jsx
+++ b/src/components/Portfolio/index.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import PortfolioGlobale from './PortfolioGlobale'
+import Positions from './Positions'
+import Edition from './Edition'
+import Performance from './Performance'
+
+const SUB_TABS = [
+  { id: 'globale', label: 'Vue Globale' },
+  { id: 'positions', label: 'Positions' },
+  { id: 'edition', label: 'Édition' },
+  { id: 'performance', label: 'Performance' },
+]
+
+export default function Portfolio(props) {
+  const [sub, setSub] = useState('globale')
+
+  return (
+    <div>
+      <div className="sub-tabs">
+        {SUB_TABS.map(t => (
+          <button
+            key={t.id}
+            className={`sub-tab${sub === t.id ? ' active' : ''}`}
+            onClick={() => setSub(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {sub === 'globale' && <PortfolioGlobale portfolio={props.portfolio} />}
+      {sub === 'positions' && <Positions portfolio={props.portfolio} />}
+      {sub === 'edition' && <Edition portfolio={props.portfolio} onSave={props.saveAll} onAdd={props.addPosition} onDelete={props.deletePosition} setIncome={props.setIncome} />}
+      {sub === 'performance' && <Performance portfolio={props.portfolio} onAddSnapshot={props.addSnapshot} onDeleteSnapshot={props.deleteSnapshot} />}
+    </div>
+  )
+}

--- a/src/components/shared/chartDefaults.js
+++ b/src/components/shared/chartDefaults.js
@@ -1,0 +1,142 @@
+export const darkGridPlugin = {
+  id: 'darkGrid',
+}
+
+export const baseChartOptions = {
+  responsive: true,
+  maintainAspectRatio: true,
+  animation: { duration: 400 },
+  plugins: {
+    legend: {
+      labels: {
+        color: '#7878a0',
+        font: { family: "'Space Mono', monospace", size: 11 },
+        boxWidth: 10,
+        padding: 16,
+      },
+    },
+    tooltip: {
+      backgroundColor: '#11111e',
+      borderColor: '#1e1e35',
+      borderWidth: 1,
+      titleColor: '#e2e2f0',
+      bodyColor: '#7878a0',
+      titleFont: { family: "'Syne', sans-serif", size: 12, weight: '700' },
+      bodyFont: { family: "'Space Mono', monospace", size: 11 },
+      padding: 10,
+      cornerRadius: 8,
+    },
+  },
+  scales: {
+    x: {
+      ticks: { color: '#7878a0', font: { family: "'Space Mono', monospace", size: 10 } },
+      grid: { color: 'rgba(30,30,53,0.8)' },
+      border: { color: '#1e1e35' },
+    },
+    y: {
+      ticks: { color: '#7878a0', font: { family: "'Space Mono', monospace", size: 10 } },
+      grid: { color: 'rgba(30,30,53,0.8)' },
+      border: { color: '#1e1e35' },
+    },
+  },
+}
+
+export const noAxesOptions = {
+  responsive: true,
+  maintainAspectRatio: true,
+  animation: { duration: 400 },
+  plugins: {
+    legend: {
+      labels: {
+        color: '#7878a0',
+        font: { family: "'Space Mono', monospace", size: 11 },
+        boxWidth: 10,
+        padding: 16,
+      },
+    },
+    tooltip: {
+      backgroundColor: '#11111e',
+      borderColor: '#1e1e35',
+      borderWidth: 1,
+      titleColor: '#e2e2f0',
+      bodyColor: '#7878a0',
+      titleFont: { family: "'Syne', sans-serif", size: 12, weight: '700' },
+      bodyFont: { family: "'Space Mono', monospace", size: 11 },
+      padding: 10,
+      cornerRadius: 8,
+    },
+  },
+}
+
+export const BUCKET_COLORS = {
+  equities: '#00d4ff',
+  gold: '#ffd94a',
+  crypto: '#a066ff',
+}
+
+export const CATEGORY_COLORS = [
+  '#00d4ff', '#ffd94a', '#a066ff', '#00e87a', '#ff8c42',
+  '#ff4466', '#40e0d0', '#ff6b9d', '#c0ff3e', '#6ec6ff',
+]
+
+export const CATEGORY_EMOJIS = {
+  Restaurants: '🍽️',
+  Courses: '🛒',
+  Divertissement: '🎬',
+  Transport: '🚗',
+  Logement: '🏠',
+  Santé: '💊',
+  Vêtements: '👕',
+  Voyages: '✈️',
+  Abonnements: '📱',
+  Autre: '💡',
+}
+
+export const CATEGORIES = Object.keys(CATEGORY_EMOJIS)
+
+export function fmtEur(n) {
+  if (n === undefined || n === null) return '—'
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(n)
+}
+
+export function fmtPct(n) {
+  if (n === undefined || n === null || !isFinite(n)) return '—'
+  const sign = n >= 0 ? '+' : ''
+  return `${sign}${n.toFixed(1)}%`
+}
+
+export function fmtNum(n, decimals = 2) {
+  if (n === undefined || n === null) return '—'
+  return new Intl.NumberFormat('fr-FR', { maximumFractionDigits: decimals }).format(n)
+}
+
+export function getMonthKey(date) {
+  const d = new Date(date)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function getLast6Months() {
+  const months = []
+  const now = new Date()
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+  }
+  return months
+}
+
+export function getCurrentMonthKey() {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function getLastMonthKey() {
+  const now = new Date()
+  const d = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+export function monthLabel(key) {
+  const [y, m] = key.split('-')
+  return new Date(+y, +m - 1, 1).toLocaleDateString('fr-FR', { month: 'short', year: '2-digit' })
+}

--- a/src/hooks/useExpenses.js
+++ b/src/hooks/useExpenses.js
@@ -1,0 +1,56 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export function useExpenses() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const fetch_ = useCallback(async () => {
+    try {
+      const res = await fetch('/api/expenses')
+      if (!res.ok) throw new Error('Failed to fetch expenses')
+      setData(await res.json())
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetch_() }, [fetch_])
+
+  const addEntry = useCallback(async (entry) => {
+    const res = await fetch('/api/expenses/entries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(entry),
+    })
+    const added = await res.json()
+    setData(prev => ({ ...prev, entries: [...prev.entries, added] }))
+    return added
+  }, [])
+
+  const deleteEntry = useCallback(async (id) => {
+    await fetch(`/api/expenses/entries/${id}`, { method: 'DELETE' })
+    setData(prev => ({ ...prev, entries: prev.entries.filter(e => e.id !== id) }))
+  }, [])
+
+  const updateBudgets = useCallback(async (budgets) => {
+    await fetch('/api/expenses/budgets', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ budgets }),
+    })
+    setData(prev => ({ ...prev, budgets }))
+  }, [])
+
+  return {
+    expenses: data,
+    loading,
+    error,
+    refetch: fetch_,
+    addEntry,
+    deleteEntry,
+    updateBudgets,
+  }
+}

--- a/src/hooks/usePortfolio.js
+++ b/src/hooks/usePortfolio.js
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export function usePortfolio() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const fetch_ = useCallback(async () => {
+    try {
+      const res = await fetch('/api/portfolio')
+      if (!res.ok) throw new Error('Failed to fetch portfolio')
+      setData(await res.json())
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetch_() }, [fetch_])
+
+  const saveAll = useCallback(async (updated) => {
+    await fetch('/api/portfolio', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated),
+    })
+    setData(updated)
+  }, [])
+
+  const addPosition = useCallback(async (position) => {
+    const res = await fetch('/api/portfolio/positions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(position),
+    })
+    const added = await res.json()
+    setData(prev => ({ ...prev, positions: [...prev.positions, added] }))
+  }, [])
+
+  const updatePosition = useCallback(async (id, updates) => {
+    await fetch(`/api/portfolio/positions/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    })
+    setData(prev => ({
+      ...prev,
+      positions: prev.positions.map(p => p.id === id ? { ...p, ...updates } : p),
+    }))
+  }, [])
+
+  const deletePosition = useCallback(async (id) => {
+    await fetch(`/api/portfolio/positions/${id}`, { method: 'DELETE' })
+    setData(prev => ({
+      ...prev,
+      positions: prev.positions.filter(p => p.id !== id),
+    }))
+  }, [])
+
+  const addSnapshot = useCallback(async (snapshot) => {
+    await fetch('/api/portfolio/snapshots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(snapshot),
+    })
+    await fetch_()
+  }, [fetch_])
+
+  const deleteSnapshot = useCallback(async (date) => {
+    await fetch(`/api/portfolio/snapshots/${encodeURIComponent(date)}`, { method: 'DELETE' })
+    setData(prev => ({
+      ...prev,
+      snapshots: prev.snapshots.filter(s => s.date !== date),
+    }))
+  }, [])
+
+  const setIncome = useCallback(async (income) => {
+    await fetch('/api/portfolio/income', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ income }),
+    })
+    setData(prev => ({ ...prev, income }))
+  }, [])
+
+  return {
+    portfolio: data,
+    loading,
+    error,
+    refetch: fetch_,
+    saveAll,
+    addPosition,
+    updatePosition,
+    deletePosition,
+    addSnapshot,
+    deleteSnapshot,
+    setIncome,
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './styles/globals.css'
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {})
+  })
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,606 @@
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap');
+
+:root {
+  --bg-primary: #0a0a0f;
+  --bg-secondary: #0d0d18;
+  --bg-card: #11111e;
+  --bg-card-hover: #161628;
+  --bg-input: #0d0d1a;
+  --border: #1e1e35;
+  --border-focus: #2e2e55;
+  --text-primary: #e2e2f0;
+  --text-secondary: #7878a0;
+  --text-muted: #44445a;
+  --accent: #00d4ff;
+  --accent-dim: rgba(0, 212, 255, 0.15);
+  --accent-glow: rgba(0, 212, 255, 0.3);
+  --green: #00e87a;
+  --green-dim: rgba(0, 232, 122, 0.15);
+  --red: #ff4466;
+  --red-dim: rgba(255, 68, 102, 0.15);
+  --gold: #ffd94a;
+  --gold-dim: rgba(255, 217, 74, 0.15);
+  --purple: #a066ff;
+  --purple-dim: rgba(160, 102, 255, 0.15);
+  --orange: #ff8c42;
+  --font-heading: 'Syne', sans-serif;
+  --font-mono: 'Space Mono', monospace;
+  --radius: 8px;
+  --radius-lg: 12px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 2px 12px rgba(0, 0, 0, 0.3);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  line-height: 1.6;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Typography */
+h1, h2, h3, h4 {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+h1 { font-size: clamp(1.5rem, 4vw, 2.25rem); }
+h2 { font-size: clamp(1.1rem, 3vw, 1.5rem); }
+h3 { font-size: clamp(0.95rem, 2.5vw, 1.15rem); }
+
+p { line-height: 1.7; }
+
+/* Layout */
+.app-header {
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.app-header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  height: 56px;
+}
+
+.app-logo {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--accent);
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+}
+
+.app-logo span {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+.main-tabs {
+  display: flex;
+  gap: 0.25rem;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.main-tabs::-webkit-scrollbar { display: none; }
+
+.main-tab {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-family: var(--font-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: all 0.15s;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.main-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+
+.main-tab.active {
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.app-main {
+  flex: 1;
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 1.5rem 1rem 3rem;
+}
+
+/* Cards */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+}
+
+.card-title {
+  font-family: var(--font-heading);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+/* KPI Cards */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.kpi-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kpi-label {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.kpi-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.kpi-delta {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.kpi-delta.positive { color: var(--green); }
+.kpi-delta.negative { color: var(--red); }
+.kpi-delta.neutral { color: var(--text-secondary); }
+
+/* Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.badge.positive { background: var(--green-dim); color: var(--green); }
+.badge.negative { background: var(--red-dim); color: var(--red); }
+.badge.neutral { background: var(--accent-dim); color: var(--accent); }
+.badge.gold { background: var(--gold-dim); color: var(--gold); }
+.badge.purple { background: var(--purple-dim); color: var(--purple); }
+.badge.type-etf { background: rgba(0,212,255,0.12); color: var(--accent); }
+.badge.type-stock { background: rgba(0,232,122,0.12); color: var(--green); }
+.badge.type-crypto { background: rgba(160,102,255,0.12); color: var(--purple); }
+.badge.type-coin { background: rgba(255,217,74,0.12); color: var(--gold); }
+.badge.type-stablecoin { background: rgba(0,232,122,0.12); color: var(--green); }
+
+/* Sub-tabs */
+.sub-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.sub-tabs::-webkit-scrollbar { display: none; }
+
+.sub-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-heading);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-bottom: -1px;
+}
+
+.sub-tab:hover { color: var(--text-primary); }
+
+.sub-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Chart containers */
+.chart-wrap {
+  position: relative;
+  width: 100%;
+}
+
+/* Grid layouts */
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+/* Table */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.data-table th {
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-family: var(--font-heading);
+  font-weight: 600;
+}
+
+.data-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid rgba(30,30,53,0.5);
+  font-family: var(--font-mono);
+}
+
+.data-table tr:hover td { background: var(--bg-card-hover); }
+
+.data-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+
+/* Forms */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-label {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--font-heading);
+  font-weight: 600;
+}
+
+.form-input, .form-select, .form-textarea {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.55rem 0.75rem;
+  transition: border-color 0.15s;
+  width: 100%;
+  appearance: none;
+}
+
+.form-input:focus, .form-select:focus, .form-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.form-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%237878a0' d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2rem;
+  cursor: pointer;
+}
+
+.form-textarea { resize: vertical; min-height: 80px; }
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1.2rem;
+  border-radius: var(--radius);
+  border: none;
+  font-family: var(--font-heading);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #000;
+}
+
+.btn-primary:hover {
+  background: #20dfff;
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.btn-secondary {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+.btn-secondary:hover { border-color: var(--border-focus); }
+
+.btn-danger {
+  background: var(--red-dim);
+  color: var(--red);
+  border: 1px solid rgba(255,68,102,0.2);
+}
+
+.btn-danger:hover { background: rgba(255,68,102,0.25); }
+
+.btn-ghost {
+  background: none;
+  color: var(--text-secondary);
+  padding: 0.3rem 0.6rem;
+}
+
+.btn-ghost:hover { color: var(--red); }
+
+.btn-sm { padding: 0.35rem 0.75rem; font-size: 0.75rem; }
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: 1rem;
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: var(--shadow);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.modal-title {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1.25rem;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.modal-close:hover { color: var(--text-primary); }
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}
+
+/* Progress bar */
+.progress-bar {
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+
+.progress-fill.ok { background: var(--accent); }
+.progress-fill.warn { background: var(--gold); }
+.progress-fill.over { background: var(--red); }
+
+/* Allocation bar */
+.alloc-bar {
+  height: 8px;
+  border-radius: 4px;
+  display: flex;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.alloc-seg {
+  height: 100%;
+  transition: flex 0.3s;
+  border-radius: 2px;
+}
+
+/* Bucket colors */
+.color-equities { color: var(--accent); }
+.color-gold { color: var(--gold); }
+.color-crypto { color: var(--purple); }
+
+.bg-equities { background: var(--accent); }
+.bg-gold { background: var(--gold); }
+.bg-crypto { background: var(--purple); }
+
+/* Section spacing */
+.section { margin-bottom: 1.5rem; }
+.section-title {
+  font-family: var(--font-heading);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* Filters */
+.filter-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.empty-state-icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-focus); }
+
+/* Utility */
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.gap-1 { gap: 0.5rem; }
+.gap-2 { gap: 1rem; }
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.text-right { text-align: right; }
+.text-mono { font-family: var(--font-mono); }
+.text-sm { font-size: 0.82rem; }
+.text-xs { font-size: 0.72rem; }
+.text-muted { color: var(--text-secondary); }
+.text-green { color: var(--green); }
+.text-red { color: var(--red); }
+.text-accent { color: var(--accent); }
+.text-gold { color: var(--gold); }
+.fw-bold { font-weight: 700; }
+
+/* Responsive */
+@media (max-width: 640px) {
+  .app-header-inner { gap: 1rem; }
+  .app-logo { font-size: 0.95rem; }
+  .app-main { padding: 1rem 0.75rem 4rem; }
+  .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+  .kpi-value { font-size: 1.25rem; }
+}
+
+@media (max-width: 400px) {
+  .kpi-grid { grid-template-columns: 1fr 1fr; }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
Full-stack React + Vite + Express app with dark terminal theme.

- Tab 1 (Dashboard): net worth KPIs, allocation donut, portfolio evolution
  line chart, spending trend, top-3 category bar chart
- Tab 2 (Portfolio): 4 sub-tabs — Vue Globale (bucket cards + charts),
  Positions (grouped table with P&L), Édition (inline value/PRU editing,
  add/delete positions, income setting), Performance (KPIs, stacked bar,
  snapshot manager)
- Tab 3 (Dépenses): monthly summary cards, category bar/trend/stacked charts,
  budget limits with progress bars + over-budget alerts, filterable expense
  list, add-expense modal
- Pre-filled positions: 10 equities, 5 gold coins, 3 crypto assets
- PWA: manifest.json + service worker for offline shell
- Express backend on :3001 with CRUD routes for portfolio + expenses JSON
- Concurrently runs both dev servers with npm run dev
- Syne + Space Mono fonts, CSS variables dark theme, Chart.js 4.x

https://claude.ai/code/session_01PJ2WAZwqNMeUtjkJvu3z4z